### PR TITLE
Change dependencies from dev-master to version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
 	],
 	"require": {
 		"php": ">=5.4",
-		"ircmaxell/random-lib": "dev-master"
-	},
-	"require-dev": {
-	    "satooshi/php-coveralls": "dev-master"
+		"ircmaxell/random-lib": "^1.2"
 	},
 	"autoload": {
 		"psr-4": {
 			"Gajus\\Paggern\\": "src/"
 		}
+	},
+	"require-dev": {
+		"satooshi/php-coveralls": "^2.0"
 	}
 }


### PR DESCRIPTION
It's annoying to use this package currently due to minimum-stability in composer.
Let's use actual version numbers instead of dev-master.